### PR TITLE
refactor the changing of card styles in recycler view

### DIFF
--- a/app/src/main/java/com/dokeraj/androtainer/DockerListerFragment.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/DockerListerFragment.kt
@@ -128,7 +128,28 @@ class DockerListerFragment : Fragment(R.layout.fragment_docker_lister) {
                     response: Response<PContainersResponse?>,
                 ) {
                     val pcResponse: PContainersResponse? = response.body()
-                    pcResponse?.let {
+
+                    if(pcResponse != null){
+                        println("ODGOVOR OD Swiper retrofit")
+                        // remap from retrofit model to regular data class
+                        val pcs: List<PContainer> = pcResponse.mapNotNull { pcr ->
+                            ContainerStateType.values().firstOrNull { xx -> xx.name == pcr.State }
+                                ?.let { cst ->
+                                    PContainer(pcr.Id, pcr.Names[0].drop(1).capitalize(),
+                                        pcr.Status, cst
+                                    )
+                                }
+                        }
+
+                        recyclerAdapter.setItems(pcs)
+                        recyclerAdapter.notifyDataSetChanged()
+                        swiperLayout.isRefreshing = false
+                    } else {
+                        // todo:: kick back to login and display snackbar
+                        swiperLayout.isRefreshing = false
+                    }
+
+                    /*pcResponse?.let {
 
                         println("ODGOVOR OD Swiper retrofit")
 
@@ -145,14 +166,15 @@ class DockerListerFragment : Fragment(R.layout.fragment_docker_lister) {
                         recyclerAdapter.setItems(pcs)
                         recyclerAdapter.notifyDataSetChanged()
                         swiperLayout.isRefreshing = false
-                    }
+                    }*/
                 }
 
                 override fun onFailure(call: Call<PContainersResponse?>, t: Throwable) {
-                    println("U EROROROOOOOOXOXOXOXOXOXOXOOXOX: ${t.message}")
+                    println("U EROROROOOOOOXOXOXOXOXOXOXOOXOX: ${t.message}") // todo:: kick back to login and display snackbar
                     Toast.makeText(activity,
                         "Server not permitting communication! Please Log in manually",
                         Toast.LENGTH_SHORT).show()
+                    swiperLayout.isRefreshing = false
                 }
             })
     }

--- a/app/src/main/java/com/dokeraj/androtainer/HomeFragment.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/HomeFragment.kt
@@ -228,7 +228,7 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
                         // remap from retrofit model to regular data class
                         val pcs: List<PContainer> = it.mapNotNull { pcr ->
                             ContainerStateType.values().firstOrNull {xx -> xx.name == pcr.State}?.let{cst ->
-                                PContainer(pcr.Id, pcr.Names[0].drop(1),
+                                PContainer(pcr.Id, pcr.Names[0].drop(1).capitalize(),
                                     pcr.Status, cst
                                 )
                             }

--- a/app/src/main/java/com/dokeraj/androtainer/adapter/DockerContainerAdapter.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/adapter/DockerContainerAdapter.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.ImageView
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
@@ -47,13 +48,78 @@ class DockerContainerAdapter(
 
         when (currentItem.state) {
             ContainerStateType.running -> {
-                setStateForRunning(currentItem.status.capitalize(), position, holder)
+                //setStateForRunning(currentItem.status.capitalize(), position, holder)
+                println("U RANING")
+
+                setCardStyle(containerState = ContainerStateType.running,
+                    statusText = currentItem.status.capitalize(),
+                    statusTextColor = R.color.disText1,
+                    cardBckColor = R.color.disGreen,
+                    buttonText = "STOP",
+                    buttonIsEnabled = true,
+                    buttonColor = R.color.btn_lister,
+                    statusIconImage = R.drawable.docker_status_icon,
+                    statusIconColor = R.color.disText1,
+                    currentItemNum = position,
+                    holder = holder
+                )
+
             }
             ContainerStateType.exited -> {
-                setStateForExited(currentItem.status.capitalize(), position, holder)
+                //setStateForExited(currentItem.status.capitalize(), position, holder)
+
+                println("U EXITED")
+
+                setCardStyle(containerState = ContainerStateType.exited,
+                    statusText = currentItem.status.capitalize(),
+                    statusTextColor = R.color.disText1,
+                    cardBckColor = R.color.disRed,
+                    buttonText = "START",
+                    buttonIsEnabled = true,
+                    buttonColor = R.color.btn_lister,
+                    statusIconImage = R.drawable.docker_status_icon,
+                    statusIconColor = R.color.disText1,
+                    currentItemNum = position,
+                    holder = holder
+                )
+
             }
             ContainerStateType.transitioning -> {
-                setTransitioningStyle(currentItem.status, position, holder)
+                //setStateForTransitioning(currentItem.status, position, holder)
+
+                println("U TRANSITIONING")
+
+                setCardStyle(containerState = ContainerStateType.transitioning,
+                    statusText = currentItem.status,
+                    statusTextColor = R.color.disText1,
+                    cardBckColor = R.color.dis6,
+                    buttonText = currentItem.status,
+                    buttonIsEnabled = false,
+                    buttonColor = R.color.dis6,
+                    statusIconImage = R.drawable.docker_status_icon,
+                    statusIconColor = R.color.disText1,
+                    currentItemNum = position,
+                    holder = holder
+                )
+
+            }
+            ContainerStateType.errored -> {
+                //setStateForError(currentItem.status, position, holder)
+
+                println("U ERROERD")
+
+                setCardStyle(containerState = ContainerStateType.errored,
+                    statusText = "Refresh by swiping down",
+                    statusTextColor = R.color.disText3,
+                    cardBckColor = R.color.disYellow,
+                    buttonText = "ERROR",
+                    buttonIsEnabled = false,
+                    buttonColor = R.color.disYellow,
+                    statusIconImage = R.drawable.warning_logo,
+                    statusIconColor = R.color.disText3,
+                    currentItemNum = position,
+                    holder = holder
+                )
             }
             /**else -> { // todo:: wait to see if there are any more states
             holder.dockerButton.text = "Issue!"
@@ -84,6 +150,7 @@ class DockerContainerAdapter(
         val dockerStatusView: TextView = itemView.etDockerStatus
         val dockerButton: Button = itemView.btnStartStop
         val cardHolderLayout: ConstraintLayout = itemView.cardHolderLayout
+        val statusIconView: ImageView = itemView.statusIcon
     }
 
     private fun startStopDockerContainer(
@@ -105,7 +172,21 @@ class DockerContainerAdapter(
         // change the style and disable button
         val transitioningText =
             if (actionType == ContainerActionType.START) "Starting" else "Exiting"
-        setTransitioningStyle(transitioningText, currentItemNum, holder)
+
+        // setStateForTransitioning(transitioningText, currentItemNum, holder)
+        println("E AJDE TRANZICIJA")
+        setCardStyle(containerState = ContainerStateType.transitioning,
+            statusText = transitioningText,
+            statusTextColor = R.color.disText1,
+            cardBckColor = R.color.dis6,
+            buttonText = transitioningText,
+            buttonIsEnabled = false,
+            buttonColor = R.color.dis6,
+            statusIconImage = R.drawable.docker_status_icon,
+            statusIconColor = R.color.disText1,
+            currentItemNum = currentItemNum,
+            holder = holder
+        )
 
         api.startStopContainer(header, urlToCall).enqueue(object : Callback<Unit?> {
             override fun onResponse(call: Call<Unit?>, response: Response<Unit?>) {
@@ -114,38 +195,136 @@ class DockerContainerAdapter(
                     204 -> {
                         println("VO 204 i action-ot so e praten: ${actionType.name}")
                         when (actionType) {
-                            ContainerActionType.START -> setStateForRunning(null,
-                                currentItemNum,
-                                holder)
-                            ContainerActionType.STOP -> setStateForExited(null,
-                                currentItemNum,
-                                holder)
+                            ContainerActionType.START -> {
+                                /*setStateForRunning("Started just now",
+                                    currentItemNum,
+                                    holder)*/
+                                setCardStyle(containerState = ContainerStateType.running,
+                                    statusText = "Started just now",
+                                    statusTextColor = R.color.disText1,
+                                    cardBckColor = R.color.disGreen,
+                                    buttonText = "STOP",
+                                    buttonIsEnabled = true,
+                                    buttonColor = R.color.btn_lister,
+                                    statusIconImage = R.drawable.docker_status_icon,
+                                    statusIconColor = R.color.disText1,
+                                    currentItemNum = currentItemNum,
+                                    holder = holder
+                                )
+                            }
+                            ContainerActionType.STOP -> {/*
+                                setStateForExited("Exited just now",
+                                    currentItemNum,
+                                    holder)*/
+                                setCardStyle(containerState = ContainerStateType.exited,
+                                    statusText = "Exited just now",
+                                    statusTextColor = R.color.disText1,
+                                    cardBckColor = R.color.disRed,
+                                    buttonText = "START",
+                                    buttonIsEnabled = true,
+                                    buttonColor = R.color.btn_lister,
+                                    statusIconImage = R.drawable.docker_status_icon,
+                                    statusIconColor = R.color.disText1,
+                                    currentItemNum = currentItemNum,
+                                    holder = holder
+                                )
+                            }
                         }
                     }
-                    304 -> {
-                        println("No change in state")
-                    }
                     else -> {
-                        // some problem?!?!
-                        println("DADE NEKOJ CUDEN KOD: ${response.code()}")
+                        //setStateForError("Refresh by swiping down", currentItemNum, holder)
+                        println("ERROR: response code: ${response.code()}")
+                        setCardStyle(containerState = ContainerStateType.errored,
+                            statusText = "Refresh by swiping down",
+                            statusTextColor = R.color.disText3,
+                            cardBckColor = R.color.disYellow,
+                            buttonText = "ERROR",
+                            buttonIsEnabled = false,
+                            buttonColor = R.color.disYellow,
+                            statusIconImage = R.drawable.warning_logo,
+                            statusIconColor = R.color.disText3,
+                            currentItemNum = currentItemNum,
+                            holder = holder
+                        )
                     }
                 }
 
             }
 
             override fun onFailure(call: Call<Unit?>, t: Throwable) {
-                println("FAILURE!!! na START/STOP!!!!!! ${t.message}")
+                // todo:: snackbar to logout manually!!
+                setCardStyle(containerState = ContainerStateType.errored,
+                    statusText = "Refresh by swiping down",
+                    statusTextColor = R.color.disText3,
+                    cardBckColor = R.color.disYellow,
+                    buttonText = "ERROR",
+                    buttonIsEnabled = false,
+                    buttonColor = R.color.disYellow,
+                    statusIconImage = R.drawable.warning_logo,
+                    statusIconColor = R.color.disText3,
+                    currentItemNum = currentItemNum,
+                    holder = holder
+                )
             }
         })
     }
 
+    private fun setCardStyle(
+        containerState: ContainerStateType,
+        statusText: String,
+        statusTextColor: Int,
+        cardBckColor: Int,
+        buttonText: String,
+        buttonIsEnabled: Boolean,
+        buttonColor: Int,
+        statusIconImage: Int,
+        statusIconColor: Int,
+        currentItemNum: Int,
+        holder: ContainerViewHolder,
+    ) {
+        pContainerList[currentItemNum].state = containerState
+        pContainerList[currentItemNum].status = statusText
+        val currentItem = pContainerList[currentItemNum]
+
+        println("AJDE OVDE SME!! holder text: ${holder.dockerNameView.text} i currentItemText: ${currentItem.name}")
+        if (holder.dockerNameView.text.toString() == currentItem.name) {
+
+            println("A VNATRE????")
+
+            // change cardHolderLayout background
+            holder.cardHolderLayout.background.colorFilter =
+                BlendModeColorFilter(ContextCompat.getColor(contekst,
+                    cardBckColor), BlendMode.SRC)
+
+            // statusView text and color
+            holder.dockerStatusView.text = currentItem.status.capitalize()
+            holder.dockerStatusView.setTextColor(ContextCompat.getColor(contekst,
+                statusTextColor))
+
+            // change button background
+            holder.dockerButton.text = buttonText
+            holder.dockerButton.isEnabled = buttonIsEnabled
+            val btnBackground = holder.dockerButton.background
+            btnBackground.mutate()
+            btnBackground.colorFilter =
+                BlendModeColorFilter(ContextCompat.getColor(contekst,
+                    buttonColor), BlendMode.SRC)
+            holder.dockerButton.background = btnBackground
+
+            // Status Icon
+            holder.statusIconView.setImageResource(statusIconImage)
+            holder.statusIconView.setColorFilter(ContextCompat.getColor(contekst,
+                statusIconColor))
+        }
+    }
+
     private fun setStateForExited(
-        statusText: String?,
+        statusText: String,
         currentItemNum: Int,
         holder: ContainerViewHolder,
     ) {
         pContainerList[currentItemNum].state = ContainerStateType.exited
-        pContainerList[currentItemNum].status = statusText ?: "Exited just now"
+        pContainerList[currentItemNum].status = statusText
         val currentItem = pContainerList[currentItemNum]
 
 
@@ -159,6 +338,8 @@ class DockerContainerAdapter(
             holder.dockerStatusView.text = currentItem.status.capitalize()
             holder.dockerButton.text = ContainerActionType.START.name
             holder.dockerButton.isEnabled = true
+            holder.dockerStatusView.setTextColor(ContextCompat.getColor(contekst,
+                R.color.disText1))
 
             // change button background
             val btnBackground = holder.dockerButton.background
@@ -171,12 +352,12 @@ class DockerContainerAdapter(
     }
 
     private fun setStateForRunning(
-        statusText: String?,
+        statusText: String,
         currentItemNum: Int,
         holder: ContainerViewHolder,
     ) {
         pContainerList[currentItemNum].state = ContainerStateType.running
-        pContainerList[currentItemNum].status = statusText ?: "Started just now"
+        pContainerList[currentItemNum].status = statusText
         val currentItem = pContainerList[currentItemNum]
 
         if (holder.dockerNameView.text.toString().trim().capitalize() == currentItem.name.trim()
@@ -188,6 +369,8 @@ class DockerContainerAdapter(
             holder.dockerStatusView.text = currentItem.status.capitalize()
             holder.dockerButton.text = ContainerActionType.STOP.name
             holder.dockerButton.isEnabled = true
+            holder.dockerStatusView.setTextColor(ContextCompat.getColor(contekst,
+                R.color.disText1))
 
             // change button background
             val btnBackground = holder.dockerButton.background
@@ -200,7 +383,7 @@ class DockerContainerAdapter(
         }
     }
 
-    private fun setTransitioningStyle(
+    private fun setStateForTransitioning(
         statusText: String,
         currentItemNum: Int,
         holder: ContainerViewHolder,
@@ -218,6 +401,8 @@ class DockerContainerAdapter(
             holder.dockerStatusView.text = currentItem.status.capitalize()
             holder.dockerButton.text = statusText
             holder.dockerButton.isEnabled = false
+            holder.dockerStatusView.setTextColor(ContextCompat.getColor(contekst,
+                R.color.disText1))
 
             // change button background
             val btnBackground = holder.dockerButton.background
@@ -225,6 +410,38 @@ class DockerContainerAdapter(
             btnBackground.colorFilter =
                 BlendModeColorFilter(ContextCompat.getColor(contekst,
                     R.color.dis6), BlendMode.SRC)
+            holder.dockerButton.background = btnBackground
+        }
+    }
+
+    private fun setStateForError(
+        // todo:: add to class the API logo
+        statusText: String,
+        currentItemNum: Int,
+        holder: ContainerViewHolder,
+    ) {
+        pContainerList[currentItemNum].state = ContainerStateType.errored
+        pContainerList[currentItemNum].status = statusText
+        val currentItem = pContainerList[currentItemNum]
+
+        if (holder.dockerNameView.text.toString().trim().capitalize() == currentItem.name.trim()
+                .capitalize()
+        ) {
+            holder.cardHolderLayout.background.colorFilter =
+                BlendModeColorFilter(ContextCompat.getColor(contekst,
+                    R.color.disYellow), BlendMode.SRC)
+            holder.dockerStatusView.text = currentItem.status.capitalize()
+            holder.dockerButton.text = "Error"
+            holder.dockerButton.isEnabled = false
+            holder.dockerStatusView.setTextColor(ContextCompat.getColor(contekst,
+                R.color.disText3))
+
+            // change button background
+            val btnBackground = holder.dockerButton.background
+            btnBackground.mutate()
+            btnBackground.colorFilter =
+                BlendModeColorFilter(ContextCompat.getColor(contekst,
+                    R.color.disYellow), BlendMode.SRC)
             holder.dockerButton.background = btnBackground
         }
     }

--- a/app/src/main/java/com/dokeraj/androtainer/models/PContainer.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/models/PContainer.kt
@@ -11,5 +11,5 @@ enum class ContainerActionType {
 }
 
 enum class ContainerStateType {
-    running, exited, transitioning
+    running, exited, transitioning, errored
 }

--- a/app/src/main/res/layout/docker_card_item.xml
+++ b/app/src/main/res/layout/docker_card_item.xml
@@ -62,7 +62,6 @@
             android:enabled="true"
             android:fontFamily="@font/ubuntu_bold"
             android:textColor="@color/disText2"
-            android:backgroundTint="@color/button_lister_background_colors"
             android:text="stop"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -16,6 +16,7 @@
     <color name="dis6">#848688</color>
     <color name="disText1">#b9bbbe</color>
     <color name="disText2">#f2ffff</color>
+    <color name="disText3">#fff000</color>
     <color name="light_gray">#4E525A</color>
     <color name="red">#C62B2B</color>
     <color name="orange_warning">#C6732B</color>
@@ -27,4 +28,5 @@
     <color name="toolbarBLue">#253041</color>
     <color name="btn_disabled">#a4d1db</color>
     <color name="btn_lister">#32c5e6</color>
+    <color name="disYellow">#998233</color>
 </resources>


### PR DESCRIPTION
- added `errored` state, which is turned on when the retrofit doesn't return 204 or when the endpoint is not reachable