### PR TITLE
add support back to android 6 marshmallow and up

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@ Note:
 - _This app supports managing of Docker containers ONLY!_
 - *This app is in no way related to the official Portainer project*
 
-<a href="https://play.google.com/store/apps/details?id=com.dokeraj.androtainer"> <img src="https://i.imgur.com/GQuE8q7.png" alt="Google Play Store" width="150"/> </a>
-
-<a href="https://apt.izzysoft.de/fdroid/index/apk/com.dokeraj.androtainer/"> <img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png" alt="IzzyOnDroid" width="160"/> </a>
-
+<a href='https://play.google.com/store/apps/details?id=com.dokeraj.androtainer&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img height="70" alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png'/></a>
+<a href="https://apt.izzysoft.de/fdroid/index/apk/com.dokeraj.androtainer/"> <img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png" alt="IzzyOnDroid" height="69"/> </a>
 
 ---------------------------------------------
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         applicationId "com.dokeraj.androtainer"
-        minSdkVersion 29
+        minSdk 23
         targetSdkVersion 31
         versionCode 20
         versionName "2.3"

--- a/app/src/main/java/com/dokeraj/androtainer/adapter/DockerContainerAdapter.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/adapter/DockerContainerAdapter.kt
@@ -3,6 +3,8 @@ package com.dokeraj.androtainer.adapter
 import android.content.Context
 import android.graphics.BlendMode
 import android.graphics.BlendModeColorFilter
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
@@ -265,9 +267,15 @@ class DockerContainerAdapter(
 
         if (holder.dockerNameView.text.toString() == currentItem.name) {
             // change cardHolderLayout background
-            holder.cardHolderLayout.background.colorFilter =
-                BlendModeColorFilter(ContextCompat.getColor(context,
-                    cardBckColor), BlendMode.SRC)
+            if (android.os.Build.VERSION.SDK_INT >= 29) {
+                holder.cardHolderLayout.background.colorFilter =
+                    BlendModeColorFilter(ContextCompat.getColor(context,
+                        cardBckColor), BlendMode.SRC)
+            } else {
+                holder.cardHolderLayout.background.colorFilter =
+                    PorterDuffColorFilter(ContextCompat.getColor(context,
+                        cardBckColor), PorterDuff.Mode.SRC)
+            }
 
             // statusView text and color
             holder.dockerStatusView.text = currentItem.status.capitalize()
@@ -281,9 +289,17 @@ class DockerContainerAdapter(
             holder.dockerButton.isEnabled = buttonIsEnabled
             val btnBackground = holder.btnBackgroundView.background
             btnBackground.mutate()
-            btnBackground.colorFilter =
-                BlendModeColorFilter(ContextCompat.getColor(context,
-                    buttonColor), BlendMode.SRC)
+
+            if (android.os.Build.VERSION.SDK_INT >= 29) {
+                btnBackground.colorFilter =
+                    BlendModeColorFilter(ContextCompat.getColor(context,
+                        buttonColor), BlendMode.SRC)
+            } else {
+                btnBackground.colorFilter =
+                    PorterDuffColorFilter(ContextCompat.getColor(context,
+                        buttonColor), PorterDuff.Mode.SRC)
+            }
+
             holder.btnBackgroundView.background = btnBackground
 
             // Status Icon

--- a/app/src/main/java/com/dokeraj/androtainer/adapter/DockerEndpointAdapter.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/adapter/DockerEndpointAdapter.kt
@@ -3,6 +3,8 @@ package com.dokeraj.androtainer.adapter
 import android.content.Context
 import android.graphics.BlendMode
 import android.graphics.BlendModeColorFilter
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -80,9 +82,15 @@ class DockerEndpointAdapter(
         bckColor: Int,
         holder: DockerEndpointViewHolder,
     ) {
-        holder.llEndpoint.background.colorFilter =
-            BlendModeColorFilter(ContextCompat.getColor(context,
-                bckColor), BlendMode.SRC)
+        if (android.os.Build.VERSION.SDK_INT >= 29) {
+            holder.llEndpoint.background.colorFilter =
+                BlendModeColorFilter(ContextCompat.getColor(context,
+                    bckColor), BlendMode.SRC)
+        } else {
+            holder.llEndpoint.background.colorFilter =
+                PorterDuffColorFilter(ContextCompat.getColor(context,
+                    bckColor), PorterDuff.Mode.SRC)
+        }
 
         holder.tvName.setTextColor(ContextCompat.getColor(context,
             textColor))

--- a/app/src/main/java/com/dokeraj/androtainer/adapter/ManageUsersAdapter.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/adapter/ManageUsersAdapter.kt
@@ -3,6 +3,8 @@ package com.dokeraj.androtainer.adapter
 import android.content.Context
 import android.graphics.BlendMode
 import android.graphics.BlendModeColorFilter
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -41,9 +43,16 @@ class ManageUsersAdapter(
         holder.tvUsername.text = currentItem.username
         holder.btnDelete.visibility = View.VISIBLE
 
-        holder.cardHolderLayout.background.colorFilter =
-            BlendModeColorFilter(ContextCompat.getColor(context,
-                R.color.dis5), BlendMode.SRC)
+        if (android.os.Build.VERSION.SDK_INT >= 29) {
+            holder.cardHolderLayout.background.colorFilter =
+                BlendModeColorFilter(ContextCompat.getColor(context,
+                    R.color.dis5), BlendMode.SRC)
+        } else {
+            holder.cardHolderLayout.background.colorFilter =
+                PorterDuffColorFilter(ContextCompat.getColor(context,
+                    R.color.dis5), PorterDuff.Mode.SRC)
+        }
+
 
         if ("${currentItem.serverUrl}.${currentItem.username}" == curLoggedUserKey)
             holder.tvCurrentUser.visibility = View.VISIBLE


### PR DESCRIPTION
This adds support for lower android versions, namely everything going back to API 23 (Android 6).

The only thing that prevented this was the use of the `BlendModeColorFilter` in 

- `DockerContainerAdapter.kt`
- `DockerEndpointAdapter.kt`
- `ManageUsersAdapter.kt`

Since the `BlendModeColorFilter` is the continuation of the since deprecated `PorterDuffColorFilter`, I just added a check for the API version for every occurrence and use the older filter if it is below 29.

Tested on LG V30, API 28 & Pixel 6 Pro Emulator, API 33

Solves #48 