### PR TITLE
Update plugins & dependencies + other housekeeping

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="1.8" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -21,5 +21,10 @@
       <option name="name" value="Google" />
       <option name="url" value="https://dl.google.com/dl/android/maven2/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -13,7 +13,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,11 +31,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
     namespace 'com.dokeraj.androtainer'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,10 +13,11 @@ android {
     compileSdkVersion 31
     buildToolsVersion "30.0.2"
 
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.dokeraj.androtainer"
-        minSdkVersion 29
-        targetSdkVersion 31
+        minSdkVersion 23
+        targetSdkVersion 33
         versionCode 20
         versionName "2.3"
 
@@ -36,38 +37,37 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+    namespace 'com.dokeraj.androtainer'
 }
 
 dependencies {
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.3.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    implementation 'com.google.code.gson:gson:2.10'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
-    implementation 'androidx.wear:wear:1.1.0'
+    implementation 'androidx.wear:wear:1.2.0'
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
+    implementation "androidx.fragment:fragment-ktx:1.5.5"
     implementation "io.noties.markwon:core:$markwon_version"
     implementation "io.noties.markwon:linkify:$markwon_version"
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation "com.google.dagger:hilt-android:2.31-alpha"
-    kapt "com.google.dagger:hilt-android-compiler:2.31-alpha"
+    implementation 'androidx.lifecycle:lifecycle-viewmodel:2.5.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
+    implementation "com.google.dagger:hilt-android:2.44.2"
+    kapt "com.google.dagger:hilt-android-compiler:2.44.2"
 
-    def hilt_viewmodels = "1.0.0-alpha02"
-    implementation "androidx.hilt:hilt-lifecycle-viewmodel:$hilt_viewmodels"
-    kapt "androidx.hilt:hilt-compiler:$hilt_viewmodels"
-
-    testImplementation 'junit:junit:4.13.1'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    compileOnly 'com.google.android.wearable:wearable:2.8.1'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    compileOnly 'com.google.android.wearable:wearable:2.9.0'
 }
 
 kapt {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.dokeraj.androtainer">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/app/src/main/java/com/dokeraj/androtainer/DockerContainerDetailsFragment.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/DockerContainerDetailsFragment.kt
@@ -146,6 +146,9 @@ class DockerContainerDetailsFragment : Fragment(R.layout.fragment_docker_contain
                 }
                 is DataState.None -> {
                 }
+
+                else -> {
+                }
             }
         })
     }

--- a/app/src/main/java/com/dokeraj/androtainer/DockerListerFragment.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/DockerListerFragment.kt
@@ -271,6 +271,8 @@ class DockerListerFragment : Fragment(R.layout.fragment_docker_lister) {
                     //recyclerAdapter.notifyItemChanged(ds.itemIndex)
                     setContainerStats(ds.data)
                 }
+
+                else -> {}
             }
         })
     }

--- a/app/src/main/java/com/dokeraj/androtainer/HomeFragment.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/HomeFragment.kt
@@ -456,8 +456,8 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
         private val SWIPE_VELOCITY_THRESHOLD = 100
 
         override fun onFling(
-            downEvent: MotionEvent?,
-            moveEvent: MotionEvent?,
+            downEvent: MotionEvent, //safe calls removed, currently conflict with compileSdkVersion 33 https://issuetracker.google.com/issues/242021191
+            moveEvent: MotionEvent,
             velocityX: Float,
             velocityY: Float,
         ): Boolean {

--- a/app/src/main/java/com/dokeraj/androtainer/HomeFragment.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/HomeFragment.kt
@@ -235,6 +235,7 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
                     disableDrawerSwipe = true
                     btnLoginState.changeBtnState(false)
                 }
+                else -> {}
             }
         })
     }

--- a/app/src/main/java/com/dokeraj/androtainer/MainActiviy.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/MainActiviy.kt
@@ -293,6 +293,10 @@ class MainActiviy : AppCompatActivity() {
 
         /** Load saved data from storage to a global var */
         initializeGlobalVar()
+
+        /** Lay out app in full screen */
+        // WindowCompat.setDecorFitsSystemWindows(window, false) // needs work
+
     }
 
 

--- a/app/src/main/java/com/dokeraj/androtainer/viewmodels/DockerListerViewModel.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/viewmodels/DockerListerViewModel.kt
@@ -1,22 +1,23 @@
 package com.dokeraj.androtainer.viewmodels
 
-import androidx.hilt.Assisted
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.*
 import com.dokeraj.androtainer.models.ContainerActionType
 import com.dokeraj.androtainer.models.ContainerStateType
 import com.dokeraj.androtainer.models.Kontainer
 import com.dokeraj.androtainer.repositories.DockerListerRepo
 import com.dokeraj.androtainer.util.DataState
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
+@HiltViewModel
 class DockerListerViewModel
-@ViewModelInject constructor(
+@Inject constructor(
     private val dockerListerRepo: DockerListerRepo,
-    @Assisted private val savedStateHandle: SavedStateHandle,
+    private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
     private val _dataState: MutableLiveData<DataState<List<Kontainer>>> = MutableLiveData()

--- a/app/src/main/java/com/dokeraj/androtainer/viewmodels/DockerListerViewModel.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/viewmodels/DockerListerViewModel.kt
@@ -45,6 +45,7 @@ class DockerListerViewModel
                                 is DataState.Loading -> {
                                     _dataState.value = dlDataState
                                 }
+                                else -> {}
                             }
                         }.launchIn(viewModelScope)
 
@@ -204,6 +205,7 @@ class DockerListerViewModel
                                     /** result back to View */
                                     _dataState.value = DataState.Error(ssState.exception)
                                 }
+                                else -> {}
                             }
                         }.launchIn(viewModelScope)
                 }

--- a/app/src/main/java/com/dokeraj/androtainer/viewmodels/HomeFragmentViewModel.kt
+++ b/app/src/main/java/com/dokeraj/androtainer/viewmodels/HomeFragmentViewModel.kt
@@ -1,20 +1,21 @@
 package com.dokeraj.androtainer.viewmodels
 
-import androidx.hilt.Assisted
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.*
 import com.dokeraj.androtainer.models.Kontainer
 import com.dokeraj.androtainer.repositories.DockerListerRepo
 import com.dokeraj.androtainer.util.DataState
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
+@HiltViewModel
 class HomeFragmentViewModel
-@ViewModelInject constructor(
+@Inject constructor(
     private val dockerListerRepo: DockerListerRepo,
-    @Assisted private val savedStateHandle: SavedStateHandle,
+    private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
     private val _dataState: MutableLiveData<DataState<List<Kontainer>>> = MutableLiveData()

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -15,6 +15,15 @@
         <item name="android:textColorPrimary">@color/blue_main</item>
         <item name="android:windowBackground">@color/dis2</item>
         <!-- Customize your theme here. -->
+        <item name="android:navigationBarColor">
+            @android:color/transparent
+        </item>
+        <item name="android:statusBarColor">
+            @android:color/transparent
+        </item>
+        <item name="android:windowLightStatusBar">
+            false
+        </item>
     </style>
 
     <style name="NavigationStyle" parent="Widget.Design.NavigationView">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,7 +10,7 @@
         <item name="colorSecondaryVariant">@color/teal_200</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+<!--        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>-->
         <item name="android:itemBackground">@color/blue_main</item>
         <item name="android:actionMenuTextColor">@color/blue_main</item>
 
@@ -18,6 +18,15 @@
         <item name="android:textColorPrimary">@color/blue_main</item>
 
         <!-- Customize your theme here. -->
+        <item name="android:navigationBarColor">
+            @android:color/transparent
+        </item>
+        <item name="android:statusBarColor">
+            @android:color/transparent
+        </item>
+        <item name="android:windowLightStatusBar">
+            false
+        </item>
     </style>
 
     <style name="NavigationStyle" parent="Widget.Design.NavigationView">

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.21"
-    ext.nav_version = "2.3.2"
-    ext.markwon_version = "4.6.0"
+    ext.kotlin_version = '1.7.20'
+    ext.nav_version = '2.3.5'
+    ext.markwon_version = '4.6.2'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.1"
-        classpath 'com.google.gms:google-services:4.3.4'
+        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.google.gms:google-services:4.3.14'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.31-alpha'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.44.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.markwon_version = '4.6.2'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
@@ -22,7 +22,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Dec 08 13:49:47 CET 2020
+#Tue Jan 03 15:34:20 CET 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
This updates any plugins/dependencies as far as possible without breaking anything (only `androidx.navigation` could not be updated to the latest version).
This necessitated some other changes:
- bumping the java version to jdk 11
- replacing @ViewModelInject with @HiltViewModel (see https://github.com/google/dagger/releases/tag/dagger-2.34)
- adding else branches to while statements in order to satisfy newer kotlin versions

Apart from that, I also set gradle to use mavenCentral instead of jcenter (since the latter one does not receive updates anymore)

The commit 3343b837b758060926507a9d253d4ece09488357 is named incorrectly, and it contains minor changes that make it so the navbar is coloured correctly on more devices